### PR TITLE
Use UA_Variant_setScalarCopy() when doing a PUT on Bool values (#3).

### DIFF
--- a/src/c/main.c
+++ b/src/c/main.c
@@ -676,7 +676,7 @@ static UA_Variant *edgex_to_opcua(edgex_device_commandresult result,
   switch (result.type)
   {
     case Bool:
-      UA_Variant_setScalar(value, &result.value.bool_result,
+      UA_Variant_setScalarCopy(value, &result.value.bool_result,
         &UA_TYPES[UA_TYPES_BOOLEAN]);
       iot_log_debug(uadr->lc, "Writing data of type %s with value %d.",
                      value->type->typeName, result.value.bool_result);


### PR DESCRIPTION
Helps prevent a double free on exit from PUT handler.
Signed-off-by: Alex McMinn <alex@iotechsys.com>